### PR TITLE
Coupler track only decouple in powered state.

### DIFF
--- a/src/main/java/mods/railcraft/world/level/block/entity/track/CouplerTrackBlockEntity.java
+++ b/src/main/java/mods/railcraft/world/level/block/entity/track/CouplerTrackBlockEntity.java
@@ -41,7 +41,9 @@ public class CouplerTrackBlockEntity extends BlockEntity {
     DECOUPLER("decoupler", 0) {
       @Override
       protected void minecartPassed(CouplerTrackBlockEntity track, AbstractMinecart cart) {
-        RollingStock.getOrThrow(cart).unlinkAll();
+        if (CouplerTrackBlock.isPowered(track.getBlockState())){
+          RollingStock.getOrThrow(cart).unlinkAll();
+        }
       }
     },
     AUTO_COUPLER("auto_coupler", 0) {

--- a/src/main/java/mods/railcraft/world/level/block/entity/track/CouplerTrackBlockEntity.java
+++ b/src/main/java/mods/railcraft/world/level/block/entity/track/CouplerTrackBlockEntity.java
@@ -41,9 +41,7 @@ public class CouplerTrackBlockEntity extends BlockEntity {
     DECOUPLER("decoupler", 0) {
       @Override
       protected void minecartPassed(CouplerTrackBlockEntity track, AbstractMinecart cart) {
-        if (CouplerTrackBlock.isPowered(track.getBlockState())){
-          RollingStock.getOrThrow(cart).unlinkAll();
-        }
+        RollingStock.getOrThrow(cart).unlinkAll();
       }
     },
     AUTO_COUPLER("auto_coupler", 0) {

--- a/src/main/java/mods/railcraft/world/level/block/track/outfitted/CouplerTrackBlock.java
+++ b/src/main/java/mods/railcraft/world/level/block/track/outfitted/CouplerTrackBlock.java
@@ -68,8 +68,10 @@ public class CouplerTrackBlock extends PoweredOutfittedTrackBlock implements Ent
   public void onMinecartPass(BlockState blockState, Level level, BlockPos pos,
       AbstractMinecart cart) {
     super.onMinecartPass(blockState, level, pos, cart);
-    level.getBlockEntity(pos, RailcraftBlockEntityTypes.COUPLER_TRACK.get())
-        .ifPresent(lockingTrack -> lockingTrack.minecartPassed(cart));
+    if (this.isPowered(blockState, level, pos)) {
+      level.getBlockEntity(pos, RailcraftBlockEntityTypes.COUPLER_TRACK.get())
+              .ifPresent(lockingTrack -> lockingTrack.minecartPassed(cart));
+    }
   }
 
   @Override

--- a/src/main/java/mods/railcraft/world/level/block/track/outfitted/CouplerTrackBlock.java
+++ b/src/main/java/mods/railcraft/world/level/block/track/outfitted/CouplerTrackBlock.java
@@ -70,7 +70,7 @@ public class CouplerTrackBlock extends PoweredOutfittedTrackBlock implements Ent
     super.onMinecartPass(blockState, level, pos, cart);
     if (this.isPowered(blockState, level, pos)) {
       level.getBlockEntity(pos, RailcraftBlockEntityTypes.COUPLER_TRACK.get())
-              .ifPresent(lockingTrack -> lockingTrack.minecartPassed(cart));
+          .ifPresent(lockingTrack -> lockingTrack.minecartPassed(cart));
     }
   }
 


### PR DESCRIPTION
**The Issue**
Coupler track in decouple mode would decouble in an unpowerstate. 

**The Proposal**
Only decouple on powered state.
 
**Possible Side Effects**
 Uses may not be expecting the change.
