### PR TITLE
Fix redstone emission for detectors

### DIFF
--- a/src/main/java/mods/railcraft/world/level/block/detector/DetectorBlock.java
+++ b/src/main/java/mods/railcraft/world/level/block/detector/DetectorBlock.java
@@ -54,7 +54,8 @@ public class DetectorBlock extends BaseEntityBlock {
   @Override
   public int getSignal(BlockState state, BlockGetter level, BlockPos pos,
       Direction direction) {
-    return state.getValue(POWERED) ? Redstone.SIGNAL_MAX : Redstone.SIGNAL_NONE;
+    return state.getValue(POWERED) && state.getValue(FACING) == direction.getOpposite()
+        ? Redstone.SIGNAL_MAX : Redstone.SIGNAL_NONE;
   }
 
   @Override

--- a/src/main/java/mods/railcraft/world/level/block/entity/detector/DetectorBlockEntity.java
+++ b/src/main/java/mods/railcraft/world/level/block/entity/detector/DetectorBlockEntity.java
@@ -59,7 +59,8 @@ public abstract class DetectorBlockEntity extends RailcraftBlockEntity {
           blockEntity.powerDelay = CartConstants.DETECTED_POWER_OUTPUT_FADE;
         }
         level.setBlockAndUpdate(blockPos, blockState.setValue(DetectorBlock.POWERED, powered));
-        level.updateNeighborsAt(blockPos, blockState.getBlock());
+        var offsetPos = blockPos.offset(blockState.getValue(DetectorBlock.FACING).getNormal());
+        level.updateNeighborsAt(offsetPos, blockState.getBlock());
       }
       blockEntity.tick = 0;
     }


### PR DESCRIPTION
**The Issue**
Cart detectors of all types fail to update redstone signals correctly; they emit strong redstone on all sides (not just the side the red dot is shown) and do not update the neighbors correctly, leading to update-suppressed redstone wires and/or components.

This can be an issue if a detector is at floor level next to a holding track; when a minecart arrives, the detector sees the minecart and powers the block without updating the rail, even if it is not facing into the block that the rail is placed on top of. Then, when the rail is powered or updated externally, the minecart can leave but the rail will remain powered because it hasn't been notified by the detector that the redstone level has changed.
 
**The Proposal**
This patch changes the behaviour of DetectorBlock to output strong redstone power in only the intended direction and changes DetectorBlockEntity to update the neighbors of the block being powered.
 
**Possible Side Effects**
Some designs making use of the fact that detectors emitted redstone on all sides may break as a result of this.
 
**Alternatives**
It is possible to modify my intersections to avoid this placement of the detector but doing so would be aesthetically displeasing and not fix the greater issue.
