### PR TITLE
Fix the signal tuning aura for token signals

### DIFF
--- a/src/api/java/mods/railcraft/api/signal/BlockEntitySignalNetwork.java
+++ b/src/api/java/mods/railcraft/api/signal/BlockEntitySignalNetwork.java
@@ -28,6 +28,9 @@ public abstract class BlockEntitySignalNetwork<T extends BlockEntityLike>
   @Override
   public boolean removePeer(BlockPos peerPos) {
     if (this.peers.remove(peerPos)) {
+      if (!this.blockEntity.getLevel().isClientSide()) {
+        this.syncToClient();
+      }
       this.blockEntity.setChanged();
       return true;
     }

--- a/src/main/java/mods/railcraft/client/renderer/blockentity/SignalAuraRenderUtil.java
+++ b/src/main/java/mods/railcraft/client/renderer/blockentity/SignalAuraRenderUtil.java
@@ -63,11 +63,6 @@ public class SignalAuraRenderUtil {
     var normal = poseStack.last().normal();
 
     for (BlockPos target : endPoints) {
-      var be = blockEntity.getLevel().getBlockEntity(target);
-      if (be == null || be.isRemoved()) {
-        continue;
-      }
-
       int color = colorProfile.getColor(blockEntity, blockEntity.getBlockPos(), target);
       float red = RenderUtil.getRed(color);
       float green = RenderUtil.getGreen(color);


### PR DESCRIPTION
Fix the signal tuning aura for token signals and fix client synchronization issue when signals or signal boxes are removed.

Token signals (and token signal boxes from #179) don't show their signalling aura lines.
After some investigation I found that a "bugfix" caused this issue:
- When a signal is removed, the client wasn't properly notified, which caused ghosting issues before the "bugfix"
- This bugfix checks for the destination position to have a block entity. No only does this break the token signals, it also doesn't properly solve the ghosting issues, for example when a different type of block entity is placed at the destination.

This patch reverts the broken "bugfix" and fixes it properly by synchronizing the client when a signal is removed. Because of this, token signal auras now also render properly.