### PR TITLE
Re-implement classic quarried stone gen

### DIFF
--- a/src/generated/resources/.cache/103d9f3f36b01595f1aa5172191e60eff02e6924
+++ b/src/generated/resources/.cache/103d9f3f36b01595f1aa5172191e60eff02e6924
@@ -1,4 +1,4 @@
-// 1.21	2024-07-02T19:04:31.428294	Registries
+// 1.21	2024-07-17T20:02:36.855970091	Registries
 febb98aea6d16a6b3ef939bd3fb613f874ea974a data/railcraft/damage_type/bore.json
 bd26d74b84c1805b9ee7dabf21ed62cf44609f5e data/railcraft/damage_type/creosote.json
 bcc0737ada4e58124e8650c74c9e1a9aae4813b2 data/railcraft/damage_type/crusher.json
@@ -28,7 +28,7 @@ dd2baa62f09bf4cb1d40da76ae78456ae6edf5da data/railcraft/worldgen/configured_feat
 48fa2ef347b10679440e414fa3b50334ae59c022 data/railcraft/worldgen/configured_feature/lead_ore.json
 3887f73ca478e303d9835fbc2d82cfaaf7f827f0 data/railcraft/worldgen/configured_feature/nickel_ore.json
 ee8f651f558efeb79c4e4359847082486c3c8f40 data/railcraft/worldgen/configured_feature/nickel_ore_small.json
-40bd61a195b460b043140c30d253bd31c654d3ec data/railcraft/worldgen/configured_feature/quarried_stone.json
+e100990e7e5237d17fd78214beef817559e21a17 data/railcraft/worldgen/configured_feature/quarried_stone.json
 3b5404cc0eccf353709dca7cf5a68e0dfaa6e1f1 data/railcraft/worldgen/configured_feature/saltpeter.json
 2580d1ea178e3680c350f6131a539e4bc4da47cf data/railcraft/worldgen/configured_feature/silver_ore.json
 ad43c894afc91acc1ff72c1864ca731914e0b9a4 data/railcraft/worldgen/configured_feature/silver_ore_buried.json
@@ -42,7 +42,7 @@ c384d5438011a2dce552db94bb4d271d1cf391fe data/railcraft/worldgen/placed_feature/
 4ec0af7fec708b193fca6d2c87d0e2ae9225a719 data/railcraft/worldgen/placed_feature/nickel_ore_middle.json
 c146c6e7d5c8abc5fbc8d602fe2e16d8129f628f data/railcraft/worldgen/placed_feature/nickel_ore_small.json
 cde6ba74c39783db1a26c6038fab3d4607f31ab6 data/railcraft/worldgen/placed_feature/nickel_ore_upper.json
-15b87dda5fffbdcc3a676ed3f21f309a8e0f877b data/railcraft/worldgen/placed_feature/quarried_stone.json
+6e1c31e3332db1a11a73056aba830065c53a09e8 data/railcraft/worldgen/placed_feature/quarried_stone.json
 53ac3c1b34599c7fc86d045afc0f70d889c309f0 data/railcraft/worldgen/placed_feature/saltpeter.json
 71163386053fb097b8bf1900113e2b664bd84806 data/railcraft/worldgen/placed_feature/silver_ore.json
 2898680fcea47c84755498a328e49156bd6f384a data/railcraft/worldgen/placed_feature/silver_ore_lower.json

--- a/src/generated/resources/.cache/4321ebcc8000f73dd5749a5c2d45335d60b185ec
+++ b/src/generated/resources/.cache/4321ebcc8000f73dd5749a5c2d45335d60b185ec
@@ -1,4 +1,4 @@
-// 1.21	2024-07-02T19:04:31.42348	Tags for minecraft:block mod id railcraft
+// 1.21	2024-07-16T20:46:04.170294748	Tags for minecraft:block mod id railcraft
 e36857f35c1bac4bde5a8450008b92cf82656216 data/c/tags/block/ore_rates/dense.json
 8ce5fa4b4f1c2619e124ef387b086d72f9c26f04 data/c/tags/block/ore_rates/singular.json
 135cfb50a5296d7842d36234ec1033fc2e454af4 data/c/tags/block/ores.json
@@ -37,6 +37,7 @@ c84bc8091a2ddab656bbcac68ac18060ef1b9eb0 data/railcraft/tags/block/iron_tank_wal
 77690ba158209beb37aa5436c376485258f75111 data/railcraft/tags/block/mineable/crowbar.json
 5c3ee0c8b144c2b48d062bca01cdc96427bb6c26 data/railcraft/tags/block/post.json
 1ecaf64f7b17425064c50cdd01fd826d38f37db5 data/railcraft/tags/block/quarried.json
+0295528cb5c194e5df814b65688466abcfd79833 data/railcraft/tags/block/quarried_replaceable_blocks.json
 8464d70cee360a2e5808a1d1d1c5b90d0230a38e data/railcraft/tags/block/reinforced_track.json
 cef2fe722cdf4386365bd961d925fa5aeb2e244e data/railcraft/tags/block/signal.json
 36dd475b78cc6cfda74baa55b8a7ba9919242524 data/railcraft/tags/block/steel_tank_gauge.json

--- a/src/generated/resources/data/railcraft/tags/block/quarried_replaceable_blocks.json
+++ b/src/generated/resources/data/railcraft/tags/block/quarried_replaceable_blocks.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "#minecraft:dirt",
+    "#minecraft:base_stone_overworld",
+    "#c:ores",
+    "minecraft:clay",
+    "minecraft:gravel"
+  ]
+}

--- a/src/generated/resources/data/railcraft/worldgen/configured_feature/quarried_stone.json
+++ b/src/generated/resources/data/railcraft/worldgen/configured_feature/quarried_stone.json
@@ -1,18 +1,15 @@
 {
-  "type": "minecraft:ore",
+  "type": "railcraft:quarried",
   "config": {
-    "discard_chance_on_air_exposure": 0.0,
-    "size": 32,
-    "targets": [
-      {
-        "state": {
-          "Name": "railcraft:quarried_stone"
-        },
-        "target": {
-          "predicate_type": "minecraft:tag_match",
-          "tag": "minecraft:base_stone_overworld"
-        }
+    "state_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "railcraft:quarried_stone"
       }
-    ]
+    },
+    "target_provider": {
+      "predicate_type": "minecraft:tag_match",
+      "tag": "railcraft:quarried_replaceable_blocks"
+    }
   }
 }

--- a/src/generated/resources/data/railcraft/worldgen/placed_feature/quarried_stone.json
+++ b/src/generated/resources/data/railcraft/worldgen/placed_feature/quarried_stone.json
@@ -2,23 +2,11 @@
   "feature": "railcraft:quarried_stone",
   "placement": [
     {
-      "type": "minecraft:count",
-      "count": 6
+      "type": "minecraft:rarity_filter",
+      "chance": 40
     },
     {
       "type": "minecraft:in_square"
-    },
-    {
-      "type": "minecraft:height_range",
-      "height": {
-        "type": "minecraft:uniform",
-        "max_inclusive": {
-          "absolute": 80
-        },
-        "min_inclusive": {
-          "absolute": 20
-        }
-      }
     },
     {
       "type": "minecraft:biome"

--- a/src/main/java/mods/railcraft/Railcraft.java
+++ b/src/main/java/mods/railcraft/Railcraft.java
@@ -76,6 +76,7 @@ import mods.railcraft.world.level.block.entity.tank.SteelTankBlockEntity;
 import mods.railcraft.world.level.block.entity.worldspike.WorldSpikeBlockEntity;
 import mods.railcraft.world.level.block.track.TrackTypes;
 import mods.railcraft.world.level.gameevent.RailcraftGameEvents;
+import mods.railcraft.world.level.levelgen.feature.RailcraftFeatures;
 import mods.railcraft.world.level.levelgen.structure.ComponentWorkshop;
 import mods.railcraft.world.level.levelgen.structure.RailcraftStructurePieces;
 import mods.railcraft.world.level.levelgen.structure.RailcraftStructureTypes;
@@ -172,6 +173,7 @@ public class Railcraft {
     RailcraftPoiTypes.register(modEventBus);
     RailcraftVillagerProfession.register(modEventBus);
     RailcraftLootModifiers.register(modEventBus);
+    RailcraftFeatures.register(modEventBus);
     RailcraftStructureTypes.register(modEventBus);
     RailcraftStructurePieces.register(modEventBus);
     RailcraftCriteriaTriggers.register(modEventBus);

--- a/src/main/java/mods/railcraft/data/RailcraftBlockTagsProvider.java
+++ b/src/main/java/mods/railcraft/data/RailcraftBlockTagsProvider.java
@@ -6,7 +6,6 @@ import mods.railcraft.tags.RailcraftTags;
 import mods.railcraft.world.level.block.RailcraftBlocks;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.neoforge.common.Tags;

--- a/src/main/java/mods/railcraft/data/RailcraftBlockTagsProvider.java
+++ b/src/main/java/mods/railcraft/data/RailcraftBlockTagsProvider.java
@@ -6,6 +6,7 @@ import mods.railcraft.tags.RailcraftTags;
 import mods.railcraft.world.level.block.RailcraftBlocks;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.neoforge.common.Tags;
@@ -347,6 +348,12 @@ public class RailcraftBlockTagsProvider extends BlockTagsProvider {
             RailcraftBlocks.ETCHED_QUARRIED_STONE.get(),
             RailcraftBlocks.QUARRIED_BRICKS.get(),
             RailcraftBlocks.QUARRIED_PAVER.get());
+    this.tag(RailcraftTags.Blocks.QUARRIED_REPLACEABLE_BLOCKS)
+        .addTags(BlockTags.DIRT)
+        .addTags(BlockTags.BASE_STONE_OVERWORLD)
+        .addTags(BlockTags.create(ResourceLocation.parse("c:ores")))
+        .add(Blocks.CLAY)
+        .add(Blocks.GRAVEL);
 
     this.tag(RailcraftTags.Blocks.ABYSSAL)
         .add(RailcraftBlocks.ABYSSAL_STONE.get(),

--- a/src/main/java/mods/railcraft/data/RailcraftBlockTagsProvider.java
+++ b/src/main/java/mods/railcraft/data/RailcraftBlockTagsProvider.java
@@ -351,7 +351,7 @@ public class RailcraftBlockTagsProvider extends BlockTagsProvider {
     this.tag(RailcraftTags.Blocks.QUARRIED_REPLACEABLE_BLOCKS)
         .addTags(BlockTags.DIRT)
         .addTags(BlockTags.BASE_STONE_OVERWORLD)
-        .addTags(BlockTags.create(ResourceLocation.parse("c:ores")))
+        .addTags(Tags.Blocks.ORES)
         .add(Blocks.CLAY)
         .add(Blocks.GRAVEL);
 

--- a/src/main/java/mods/railcraft/data/worldgen/features/RailcraftOreFeatures.java
+++ b/src/main/java/mods/railcraft/data/worldgen/features/RailcraftOreFeatures.java
@@ -4,7 +4,10 @@ import java.util.List;
 import java.util.function.Supplier;
 import com.google.common.base.Suppliers;
 import mods.railcraft.api.core.RailcraftConstants;
+import mods.railcraft.tags.RailcraftTags;
 import mods.railcraft.world.level.block.RailcraftBlocks;
+import mods.railcraft.world.level.levelgen.feature.RailcraftFeatures;
+import mods.railcraft.world.level.levelgen.feature.configuration.QuarriedConfiguration;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.resources.ResourceKey;
@@ -17,6 +20,7 @@ import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.DiskConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
 import net.minecraft.world.level.levelgen.feature.stateproviders.RuleBasedBlockStateProvider;
 import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
 
@@ -30,14 +34,13 @@ public class RailcraftOreFeatures {
   private static final int NICKEL_VEIN_DIMENSION = 7;
   private static final int NICKEL_SMALL_VEIN_DIMENSION = 4;
   private static final int SILVER_VEIN_DIMENSION = 10;
-  private static final int QUARRIED_STONE_VEIN_DIMENSION = 32;
 
   private static final TagMatchTest STONE_ORE_REPLACEABLES =
       new TagMatchTest(BlockTags.STONE_ORE_REPLACEABLES);
   private static final TagMatchTest DEEPSLATE_ORE_REPLACEABLES =
       new TagMatchTest(BlockTags.DEEPSLATE_ORE_REPLACEABLES);
-  private static final TagMatchTest BASE_STONE_OVERWORLD =
-      new TagMatchTest(BlockTags.BASE_STONE_OVERWORLD);
+  private static final TagMatchTest QUARRIED_REPLACEABLE_BLOCKS =
+      new TagMatchTest(RailcraftTags.Blocks.QUARRIED_REPLACEABLE_BLOCKS);
 
   private static final Supplier<List<OreConfiguration.TargetBlockState>> LEAD_ORE_TARGET_LIST =
       Suppliers.memoize(() -> List.of(
@@ -117,10 +120,10 @@ public class RailcraftOreFeatures {
         new OreConfiguration(SILVER_ORE_TARGET_LIST.get(), SILVER_VEIN_DIMENSION)));
     context.register(SILVER_ORE_BURIED, new ConfiguredFeature<>(Feature.ORE,
         new OreConfiguration(SILVER_ORE_TARGET_LIST.get(), SILVER_VEIN_DIMENSION, 0.5F)));
-    context.register(QUARRIED_STONE, new ConfiguredFeature<>(Feature.ORE,
-        new OreConfiguration(BASE_STONE_OVERWORLD,
-            RailcraftBlocks.QUARRIED_STONE.get().defaultBlockState(),
-            QUARRIED_STONE_VEIN_DIMENSION)));
+    context.register(QUARRIED_STONE, new ConfiguredFeature<>(RailcraftFeatures.QUARRIED_STONE.get(),
+        new QuarriedConfiguration(
+            QUARRIED_REPLACEABLE_BLOCKS,
+            BlockStateProvider.simple(RailcraftBlocks.QUARRIED_STONE.get()))));
     context.register(SALTPETER, new ConfiguredFeature<>(Feature.DISK,
         new DiskConfiguration(
             RuleBasedBlockStateProvider.simple(RailcraftBlocks.SALTPETER_ORE.get()),

--- a/src/main/java/mods/railcraft/data/worldgen/placements/RailcraftOrePlacements.java
+++ b/src/main/java/mods/railcraft/data/worldgen/placements/RailcraftOrePlacements.java
@@ -1,6 +1,7 @@
 package mods.railcraft.data.worldgen.placements;
 
 import java.util.List;
+
 import org.jetbrains.annotations.NotNull;
 import mods.railcraft.api.core.RailcraftConstants;
 import mods.railcraft.data.worldgen.features.RailcraftOreFeatures;
@@ -14,12 +15,7 @@ import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
-import net.minecraft.world.level.levelgen.placement.BiomeFilter;
-import net.minecraft.world.level.levelgen.placement.BlockPredicateFilter;
-import net.minecraft.world.level.levelgen.placement.CountPlacement;
-import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
-import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
-import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.*;
 import net.minecraft.world.level.material.Fluids;
 
 public class RailcraftOrePlacements {
@@ -111,9 +107,10 @@ public class RailcraftOrePlacements {
                     VerticalAnchor.absolute(-48)))));
     context.register(QUARRIED_STONE,
         new PlacedFeature(getConfiguredFeature(context, RailcraftOreFeatures.QUARRIED_STONE),
-            OrePlacements.commonOrePlacement(6,
-                HeightRangePlacement.uniform(VerticalAnchor.absolute(20),
-                    VerticalAnchor.absolute(80)))));
+            List.of(
+                RarityFilter.onAverageOnceEvery(40),
+                InSquarePlacement.spread(),
+                BiomeFilter.biome())));
     context.register(SALTPETER,
         new PlacedFeature(getConfiguredFeature(context, RailcraftOreFeatures.SALTPETER),
             List.of(

--- a/src/main/java/mods/railcraft/data/worldgen/placements/RailcraftOrePlacements.java
+++ b/src/main/java/mods/railcraft/data/worldgen/placements/RailcraftOrePlacements.java
@@ -1,7 +1,6 @@
 package mods.railcraft.data.worldgen.placements;
 
 import java.util.List;
-
 import org.jetbrains.annotations.NotNull;
 import mods.railcraft.api.core.RailcraftConstants;
 import mods.railcraft.data.worldgen.features.RailcraftOreFeatures;
@@ -15,7 +14,13 @@ import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
-import net.minecraft.world.level.levelgen.placement.*;
+import net.minecraft.world.level.levelgen.placement.BiomeFilter;
+import net.minecraft.world.level.levelgen.placement.BlockPredicateFilter;
+import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.RarityFilter;
 import net.minecraft.world.level.material.Fluids;
 
 public class RailcraftOrePlacements {

--- a/src/main/java/mods/railcraft/tags/RailcraftTags.java
+++ b/src/main/java/mods/railcraft/tags/RailcraftTags.java
@@ -226,6 +226,9 @@ public class RailcraftTags {
     public static final TagKey<Block> STEEL_TANK_WALL = tag("steel_tank_wall");
 
     public static final TagKey<Block> QUARRIED = tag("quarried");
+    public static final TagKey<Block> QUARRIED_REPLACEABLE_BLOCKS =
+        tag("quarried_replaceable_blocks");
+
     public static final TagKey<Block> ABYSSAL = tag("abyssal");
     public static final TagKey<Block> DETECTOR = tag("detector");
 

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/QuarriedFeature.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/QuarriedFeature.java
@@ -1,7 +1,7 @@
 package mods.railcraft.world.level.levelgen.feature;
 
 import com.mojang.serialization.Codec;
-
+import mods.railcraft.world.level.levelgen.feature.configuration.QuarriedConfiguration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.tags.BlockTags;
@@ -14,99 +14,96 @@ import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 
-import mods.railcraft.world.level.levelgen.feature.configuration.QuarriedConfiguration;
-
 public class QuarriedFeature extends Feature<QuarriedConfiguration> {
 
-    private static final int DISTANCE_OUTER_SQ = 8 * 8;
+  private static final int DISTANCE_OUTER_SQ = 8 * 8;
 
-    public QuarriedFeature(Codec<QuarriedConfiguration> codec) {
-        super(codec);
+  public QuarriedFeature(Codec<QuarriedConfiguration> codec) {
+    super(codec);
+  }
+
+  @Override
+  public boolean place(FeaturePlaceContext<QuarriedConfiguration> context) {
+    var level = context.level();
+    var origin = level
+        .getHeightmapPos(Heightmap.Types.WORLD_SURFACE_WG, context.origin())
+        .below(3);
+    if (!level.getBlockState(origin).is(BlockTags.DIRT))
+      return false;
+
+    final var currentPos = new BlockPos.MutableBlockPos();
+
+    boolean clearTop = true;
+    for (int x = -8; x < 8; x++) {
+      for (int z = -8; z < 8; z++) {
+        for (int y = 1; y < 4 && y + origin.getY() < level.getHeight() - 1; y++) {
+          final int distSq = x * x + z * z;
+          if (distSq > DISTANCE_OUTER_SQ)
+            continue;
+
+          currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
+          if (level.getBlockState(currentPos).getBlock() instanceof LiquidBlock)
+            clearTop = false;
+        }
+      }
     }
 
-    @Override
-    public boolean place(FeaturePlaceContext<QuarriedConfiguration> context) {
-        final WorldGenLevel level = context.level();
-        final BlockPos origin =
-            level
-                .getHeightmapPos(Heightmap.Types.WORLD_SURFACE_WG, context.origin())
-                .below(3);
-        if (!level.getBlockState(origin).is(BlockTags.DIRT))
-            return false;
+    if (clearTop) {
+      for (int x = -8; x < 8; x++) {
+        for (int z = -8; z < 8; z++) {
+          for (int y = 1; y < 4 && y + origin.getY() < level.getHeight() - 1; y++) {
+            final int distSq = x * x + z * z;
+            if (distSq > DISTANCE_OUTER_SQ)
+              continue;
 
-        final var currentPos = new BlockPos.MutableBlockPos();
-
-        boolean clearTop = true;
-        for (int x = -8; x < 8; x++) {
-            for (int z = -8; z < 8; z++) {
-                for (int y = 1; y < 4 && y + origin.getY() < level.getHeight() - 1; y++) {
-                    final int distSq = x * x + z * z;
-                    if (distSq > DISTANCE_OUTER_SQ)
-                        continue;
-
-                    currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
-                    if (level.getBlockState(currentPos).getBlock() instanceof LiquidBlock)
-                        clearTop = false;
-                }
-            }
+            currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
+            final BlockState existingState = level.getBlockState(currentPos);
+            if (!placeAir(existingState, level, currentPos))
+              break;
+          }
         }
-
-        if (clearTop) {
-            for (int x = -8; x < 8; x++) {
-                for (int z = -8; z < 8; z++) {
-                    for (int y = 1; y < 4 && y + origin.getY() < level.getHeight() - 1; y++) {
-                        final int distSq = x * x + z * z;
-                        if (distSq > DISTANCE_OUTER_SQ)
-                            continue;
-
-                        currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
-                        final BlockState existingState = level.getBlockState(currentPos);
-                        if (!placeAir(existingState, level, currentPos))
-                            break;
-                    }
-                }
-            }
-        }
-
-        for (int x = -8; x < 8; x++) {
-            for (int z = -8; z < 8; z++) {
-                for (int y = -8; y < 1 && y + origin.getY() < level.getHeight() - 1; y++) {
-                    final int distSq = x * x + z * z + y * y;
-                    if (distSq > DISTANCE_OUTER_SQ)
-                        continue;
-
-                    currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
-                    final BlockState existingState = level.getBlockState(currentPos);
-                    placeState(existingState, level, currentPos, context.random(), context.config());
-                }
-            }
-        }
-        return true;
+      }
     }
 
-    private boolean placeAir(BlockState existingState, WorldGenLevel level, BlockPos blockPos) {
-        BlockPos above = blockPos.above();
-        if (!level.isEmptyBlock(above) || (existingState.getBlock() instanceof LiquidBlock))
-            return false;
+    for (int x = -8; x < 8; x++) {
+      for (int z = -8; z < 8; z++) {
+        for (int y = -8; y < 1 && y + origin.getY() < level.getHeight() - 1; y++) {
+          final int distSq = x * x + z * z + y * y;
+          if (distSq > DISTANCE_OUTER_SQ)
+            continue;
 
-        for (var direction : Direction.Plane.HORIZONTAL) {
-            BlockPos target = above.relative(direction);
-
-            if (!level.isEmptyBlock(target))
-                return false;
+          currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
+          final BlockState existingState = level.getBlockState(currentPos);
+          placeState(existingState, level, currentPos, context.random(), context.config());
         }
+      }
+    }
+    return true;
+  }
 
-        level.setBlock(blockPos, Blocks.AIR.defaultBlockState(), 2);
-        return true;
+  private boolean placeAir(BlockState existingState, WorldGenLevel level, BlockPos blockPos) {
+    var above = blockPos.above();
+    if (!level.isEmptyBlock(above) || (existingState.getBlock() instanceof LiquidBlock))
+      return false;
+
+    for (var direction : Direction.Plane.HORIZONTAL) {
+      var target = above.relative(direction);
+
+      if (!level.isEmptyBlock(target))
+        return false;
     }
 
-    private void placeState(BlockState existingState, WorldGenLevel level, BlockPos blockPos,
-                            RandomSource random, QuarriedConfiguration config) {
-        BlockPos above = blockPos.above();
-        if (level.getBlockState(above).is(Blocks.SHORT_GRASS))
-            level.setBlock(above, Blocks.AIR.defaultBlockState(), 2);
+    level.setBlock(blockPos, Blocks.AIR.defaultBlockState(), 2);
+    return true;
+  }
 
-        if (config.targetProvider().test(existingState, random))
-            level.setBlock(blockPos, config.stateProvider().getState(random, blockPos), 2);
-    }
+  private void placeState(BlockState existingState, WorldGenLevel level, BlockPos blockPos,
+      RandomSource random, QuarriedConfiguration config) {
+    var above = blockPos.above();
+    if (level.getBlockState(above).is(Blocks.SHORT_GRASS))
+      level.setBlock(above, Blocks.AIR.defaultBlockState(), 2);
+
+    if (config.targetProvider().test(existingState, random))
+      level.setBlock(blockPos, config.stateProvider().getState(random, blockPos), 2);
+  }
 }

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/QuarriedFeature.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/QuarriedFeature.java
@@ -1,0 +1,112 @@
+package mods.railcraft.world.level.levelgen.feature;
+
+import com.mojang.serialization.Codec;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
+
+import mods.railcraft.world.level.levelgen.feature.configuration.QuarriedConfiguration;
+
+public class QuarriedFeature extends Feature<QuarriedConfiguration> {
+
+    private static final int DISTANCE_OUTER_SQ = 8 * 8;
+
+    public QuarriedFeature(Codec<QuarriedConfiguration> codec) {
+        super(codec);
+    }
+
+    @Override
+    public boolean place(FeaturePlaceContext<QuarriedConfiguration> context) {
+        final WorldGenLevel level = context.level();
+        final BlockPos origin =
+            level
+                .getHeightmapPos(Heightmap.Types.WORLD_SURFACE_WG, context.origin())
+                .below(3);
+        if (!level.getBlockState(origin).is(BlockTags.DIRT))
+            return false;
+
+        final var currentPos = new BlockPos.MutableBlockPos();
+
+        boolean clearTop = true;
+        for (int x = -8; x < 8; x++) {
+            for (int z = -8; z < 8; z++) {
+                for (int y = 1; y < 4 && y + origin.getY() < level.getHeight() - 1; y++) {
+                    final int distSq = x * x + z * z;
+                    if (distSq > DISTANCE_OUTER_SQ)
+                        continue;
+
+                    currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
+                    if (level.getBlockState(currentPos).getBlock() instanceof LiquidBlock)
+                        clearTop = false;
+                }
+            }
+        }
+
+        if (clearTop) {
+            for (int x = -8; x < 8; x++) {
+                for (int z = -8; z < 8; z++) {
+                    for (int y = 1; y < 4 && y + origin.getY() < level.getHeight() - 1; y++) {
+                        final int distSq = x * x + z * z;
+                        if (distSq > DISTANCE_OUTER_SQ)
+                            continue;
+
+                        currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
+                        final BlockState existingState = level.getBlockState(currentPos);
+                        if (!placeAir(existingState, level, currentPos))
+                            break;
+                    }
+                }
+            }
+        }
+
+        for (int x = -8; x < 8; x++) {
+            for (int z = -8; z < 8; z++) {
+                for (int y = -8; y < 1 && y + origin.getY() < level.getHeight() - 1; y++) {
+                    final int distSq = x * x + z * z + y * y;
+                    if (distSq > DISTANCE_OUTER_SQ)
+                        continue;
+
+                    currentPos.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
+                    final BlockState existingState = level.getBlockState(currentPos);
+                    placeState(existingState, level, currentPos, context.random(), context.config());
+                }
+            }
+        }
+        return true;
+    }
+
+    private boolean placeAir(BlockState existingState, WorldGenLevel level, BlockPos blockPos) {
+        BlockPos above = blockPos.above();
+        if (!level.isEmptyBlock(above) || (existingState.getBlock() instanceof LiquidBlock))
+            return false;
+
+        for (var direction : Direction.Plane.HORIZONTAL) {
+            BlockPos target = above.relative(direction);
+
+            if (!level.isEmptyBlock(target))
+                return false;
+        }
+
+        level.setBlock(blockPos, Blocks.AIR.defaultBlockState(), 2);
+        return true;
+    }
+
+    private void placeState(BlockState existingState, WorldGenLevel level, BlockPos blockPos,
+                            RandomSource random, QuarriedConfiguration config) {
+        BlockPos above = blockPos.above();
+        if (level.getBlockState(above).is(Blocks.SHORT_GRASS))
+            level.setBlock(above, Blocks.AIR.defaultBlockState(), 2);
+
+        if (config.targetProvider().test(existingState, random))
+            level.setBlock(blockPos, config.stateProvider().getState(random, blockPos), 2);
+    }
+}

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/QuarriedFeature.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/QuarriedFeature.java
@@ -7,6 +7,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -93,7 +94,7 @@ public class QuarriedFeature extends Feature<QuarriedConfiguration> {
         return false;
     }
 
-    level.setBlock(blockPos, Blocks.AIR.defaultBlockState(), 2);
+    level.setBlock(blockPos, Blocks.AIR.defaultBlockState(), Block.UPDATE_CLIENTS);
     return true;
   }
 
@@ -101,9 +102,9 @@ public class QuarriedFeature extends Feature<QuarriedConfiguration> {
       RandomSource random, QuarriedConfiguration config) {
     var above = blockPos.above();
     if (level.getBlockState(above).is(Blocks.SHORT_GRASS))
-      level.setBlock(above, Blocks.AIR.defaultBlockState(), 2);
+      level.setBlock(above, Blocks.AIR.defaultBlockState(), Block.UPDATE_CLIENTS);
 
     if (config.targetProvider().test(existingState, random))
-      level.setBlock(blockPos, config.stateProvider().getState(random, blockPos), 2);
+      level.setBlock(blockPos, config.stateProvider().getState(random, blockPos), Block.UPDATE_CLIENTS);
   }
 }

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/RailcraftFeatures.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/RailcraftFeatures.java
@@ -1,23 +1,22 @@
 package mods.railcraft.world.level.levelgen.feature;
 
+import mods.railcraft.api.core.RailcraftConstants;
+import mods.railcraft.world.level.levelgen.feature.configuration.QuarriedConfiguration;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
-import mods.railcraft.api.core.RailcraftConstants;
-import mods.railcraft.world.level.levelgen.feature.configuration.QuarriedConfiguration;
-
 public class RailcraftFeatures {
 
-    private static final DeferredRegister<Feature<?>> FEATURES =
-        DeferredRegister.create(Registries.FEATURE, RailcraftConstants.ID);
+  private static final DeferredRegister<Feature<?>> deferredRegister =
+      DeferredRegister.create(Registries.FEATURE, RailcraftConstants.ID);
 
-    public static final DeferredHolder<Feature<?>, QuarriedFeature> QUARRIED_STONE =
-        FEATURES.register("quarried", () -> new QuarriedFeature(QuarriedConfiguration.CODEC));
+  public static final DeferredHolder<Feature<?>, QuarriedFeature> QUARRIED_STONE =
+      deferredRegister.register("quarried", () -> new QuarriedFeature(QuarriedConfiguration.CODEC));
 
-    public static void register(IEventBus eventBus) {
-        FEATURES.register(eventBus);
-    }
+  public static void register(IEventBus eventBus) {
+    deferredRegister.register(eventBus);
+  }
 }

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/RailcraftFeatures.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/RailcraftFeatures.java
@@ -1,0 +1,23 @@
+package mods.railcraft.world.level.levelgen.feature;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import mods.railcraft.api.core.RailcraftConstants;
+import mods.railcraft.world.level.levelgen.feature.configuration.QuarriedConfiguration;
+
+public class RailcraftFeatures {
+
+    private static final DeferredRegister<Feature<?>> FEATURES =
+        DeferredRegister.create(Registries.FEATURE, RailcraftConstants.ID);
+
+    public static final DeferredHolder<Feature<?>, QuarriedFeature> QUARRIED_STONE =
+        FEATURES.register("quarried", () -> new QuarriedFeature(QuarriedConfiguration.CODEC));
+
+    public static void register(IEventBus eventBus) {
+        FEATURES.register(eventBus);
+    }
+}

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/configuration/QuarriedConfiguration.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/configuration/QuarriedConfiguration.java
@@ -2,22 +2,18 @@ package mods.railcraft.world.level.levelgen.feature.configuration;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-
 import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
 import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
 import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
 
-public record QuarriedConfiguration(RuleTest targetProvider,
-                                    BlockStateProvider stateProvider) implements FeatureConfiguration {
+public record QuarriedConfiguration(
+    RuleTest targetProvider, BlockStateProvider stateProvider) implements FeatureConfiguration {
 
-    public static final Codec<QuarriedConfiguration> CODEC = RecordCodecBuilder.create(instance ->
-        instance
-            .group(
-                RuleTest.CODEC
-                    .fieldOf("target_provider")
-                    .forGetter(QuarriedConfiguration::targetProvider),
-                BlockStateProvider.CODEC
-                    .fieldOf("state_provider")
-                    .forGetter(QuarriedConfiguration::stateProvider))
-            .apply(instance, QuarriedConfiguration::new));
+  public static final Codec<QuarriedConfiguration> CODEC =
+      RecordCodecBuilder.create(instance -> instance.group(
+          RuleTest.CODEC.fieldOf("target_provider")
+              .forGetter(QuarriedConfiguration::targetProvider),
+          BlockStateProvider.CODEC.fieldOf("state_provider")
+              .forGetter(QuarriedConfiguration::stateProvider)
+      ).apply(instance, QuarriedConfiguration::new));
 }

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/configuration/QuarriedConfiguration.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/configuration/QuarriedConfiguration.java
@@ -1,0 +1,23 @@
+package mods.railcraft.world.level.levelgen.feature.configuration;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
+import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
+import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
+
+public record QuarriedConfiguration(RuleTest targetProvider,
+                                    BlockStateProvider stateProvider) implements FeatureConfiguration {
+
+    public static final Codec<QuarriedConfiguration> CODEC = RecordCodecBuilder.create(instance ->
+        instance
+            .group(
+                RuleTest.CODEC
+                    .fieldOf("target_provider")
+                    .forGetter(QuarriedConfiguration::targetProvider),
+                BlockStateProvider.CODEC
+                    .fieldOf("state_provider")
+                    .forGetter(QuarriedConfiguration::stateProvider))
+            .apply(instance, QuarriedConfiguration::new));
+}

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/package-info.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/package-info.java
@@ -1,0 +1,9 @@
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package mods.railcraft.world.level.levelgen.feature;
+
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/mods/railcraft/world/level/levelgen/feature/package-info.java
+++ b/src/main/java/mods/railcraft/world/level/levelgen/feature/package-info.java
@@ -3,7 +3,6 @@
 @ParametersAreNonnullByDefault
 package mods.railcraft.world.level.levelgen.feature;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.FieldsAreNonnullByDefault;
 import net.minecraft.MethodsReturnNonnullByDefault;
-
-import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
**The Issue**

Railcraft Reborn currently generates quarried stone using the regular `minecraft:ore` feature. I've always liked the more unique ways Railcraft used to generate resources and would thus like to see it reintroduced.
 
**The Proposal**

This PR restores the classic quarried stone generation using a custom `railcraft:quarried` feature. The old generation logic has mostly been ported over and is made a bit more flexible through the use of `QuarryConfiguration` as configured feature, allowing configuration of the blocks to place (i.e., `railcraft:quarried_stone` by default) and the target blocks which are allowed to be replaced during generation (i.e., all blocks matched by the newly introduced `#railcraft:quarried_replaceable_blocks` tag).

**Possible Side Effects**

I'm not aware of any side effects except changing the generated amount of quarried stone back to its original amount which is likely lower than the amount currently generated using the `minecraft:ore` feature.
 
**Alternatives**

The alternative would be to keep the status quo.