### PR TITLE
FIX #243

### DIFF
--- a/src/generated/resources/data/railcraft/tags/block/tunnel_bore_mineable_blocks.json
+++ b/src/generated/resources/data/railcraft/tags/block/tunnel_bore_mineable_blocks.json
@@ -33,6 +33,7 @@
     "minecraft:end_stone",
     "#c:ores",
     "#c:netherracks",
+    "#c:stones",
     "#c:cobblestones",
     "#c:obsidians",
     "#c:gravels",


### PR DESCRIPTION
Tunnel Bore does not mine diorite, deepslate or granite on a single player game

**The Issue**
#243 
 
**The Proposal**
add stones tags to tunnel bore mineable block
 
**Possible Side Effects**
None 
 
**Alternatives**
Add a config option like boreMinesAllBlocks in server into client (But i don’t know if it will have an effect)
