### PR TITLE
Output Craft Remainder of a Fuel Slot

### DIFF
--- a/src/main/java/mods/railcraft/mixin/MinecartFurnaceMixin.java
+++ b/src/main/java/mods/railcraft/mixin/MinecartFurnaceMixin.java
@@ -43,7 +43,11 @@ public abstract class MinecartFurnaceMixin extends AbstractMinecart {
     var burnTime = itemstack.getBurnTime(null);
     if (burnTime > 0 && this.fuel + burnTime <= 32000) {
       if (!player.getAbilities().instabuild) {
+        var craftRemainder = itemstack.getCraftingRemainingItem();
         itemstack.shrink(1);
+        if (itemstack.isEmpty()) {
+          player.setItemInHand(hand, craftRemainder);
+        }
       }
 
       this.fuel += burnTime;

--- a/src/main/java/mods/railcraft/world/module/BlastFurnaceModule.java
+++ b/src/main/java/mods/railcraft/world/module/BlastFurnaceModule.java
@@ -137,8 +137,9 @@ public class BlastFurnaceModule extends CookingModule<BlastFurnaceRecipe, BlastF
     }
     this.currentItemBurnTime = itemBurnTime + this.burnTime;
     this.setBurnTime(this.currentItemBurnTime);
+    var craftRemainder = fuel.getCraftingRemainingItem();
     fuel.shrink(1);
-    this.setItem(SLOT_FUEL, fuel.isEmpty() ? ItemStack.EMPTY : fuel);
+    this.setItem(SLOT_FUEL, fuel.isEmpty() ? craftRemainder : fuel);
   }
 
   public void setBurnTime(int burnTime) {


### PR DESCRIPTION
**The Issue**
Closes #250 

When using either the Minecart Furnace or the Blasting Furnace multiblock module, the slot may consume the item unintentionally. In normal behavior, the furnace would output whatever was left behind directly into the fuel slot once it was empty. However, the extensions here consume the item, regardless of if it leaves something behind.
 
**The Proposal**
The changes made get the crafting remainder item before the stack is decremented and sets it if the item stack, after shrinking, is empty. This allows the furnaces to be consistent with vanilla behavior.
 
**Possible Side Effects**
Normally, items that have a crafting remainder have a stack size of 1, so this method does not consider what happens when a crafting remainder should be outputted for all items. As mojang themselves hasn't really answered this question yet, it is up to the developers to determine how crafting remainder for stackable items should work. This implementation simply considers it after the stack is empty.
 
**Alternatives**
No alternative solutions were considered.
