### PR TITLE
Fixes #301: Token signals become disconnected on world reload

### DIFF
--- a/src/main/java/mods/railcraft/world/level/block/entity/signal/TokenSignalBlockEntity.java
+++ b/src/main/java/mods/railcraft/world/level/block/entity/signal/TokenSignalBlockEntity.java
@@ -135,6 +135,7 @@ public class TokenSignalBlockEntity extends AbstractSignalBlockEntity
 
   public void setRingId(UUID tokenRingId) {
     this.ringId = tokenRingId;
+    this.setChanged();
   }
 
   @Override

--- a/src/main/java/mods/railcraft/world/level/block/entity/signal/TokenSignalBoxBlockEntity.java
+++ b/src/main/java/mods/railcraft/world/level/block/entity/signal/TokenSignalBoxBlockEntity.java
@@ -149,6 +149,7 @@ public class TokenSignalBoxBlockEntity extends ActionSignalBoxBlockEntity
 
   public void setRingId(UUID tokenRingId) {
     this.ringId = tokenRingId;
+    this.setChanged();
   }
 
   @Override

--- a/src/main/java/mods/railcraft/world/signal/SimpleTokenRing.java
+++ b/src/main/java/mods/railcraft/world/signal/SimpleTokenRing.java
@@ -95,7 +95,15 @@ public class SimpleTokenRing implements TokenRing {
   }
 
   public boolean isOrphaned(ServerLevel level) {
-    return !this.peers.stream().map(this::peerAt).allMatch(Optional::isPresent);
+    return this.peers.stream().allMatch(this::isNotTokenSignalEntity);
+  }
+
+  boolean isNotTokenSignalEntity(BlockPos blockPos) {
+    if (!this.level.isLoaded(blockPos)) {
+      return false;
+    }
+    var blockEntity = this.level.getBlockEntity(blockPos);
+    return !(blockEntity instanceof TokenSignalEntity) || blockEntity.isRemoved();
   }
 
   void loadSignals(Collection<BlockPos> signals) {


### PR DESCRIPTION
* Updating ringId doesn't trigger BlockEntity.setChanged(), therefore the change is not persisted across world reload.
* isOrphaned incorrently purges any token ring with unloaded token signals.