### PR TITLE
Fixes #311: Allow worldspike carts pass items trough the train

### DIFF
--- a/src/main/java/mods/railcraft/world/entity/vehicle/WorldSpikeMinecart.java
+++ b/src/main/java/mods/railcraft/world/entity/vehicle/WorldSpikeMinecart.java
@@ -33,6 +33,11 @@ public class WorldSpikeMinecart extends RailcraftMinecart {
   }
 
   @Override
+  public boolean canPassItemRequests(ItemStack stack) {
+    return true;
+  }
+
+  @Override
   public BlockState getDefaultDisplayBlockState() {
     return RailcraftBlocks.WORLD_SPIKE.get().defaultBlockState();
   }


### PR DESCRIPTION
Allow worldspike carts pass items trough the train, so they can be used to keep the tunnel bore loaded while still allowing track remover carts to work.
