### PR TITLE
1.20.x steel axe rebalance

### DIFF
--- a/src/main/java/mods/railcraft/world/item/RailcraftItems.java
+++ b/src/main/java/mods/railcraft/world/item/RailcraftItems.java
@@ -260,7 +260,7 @@ public class RailcraftItems {
 
   public static final RegistryObject<AxeItem> STEEL_AXE =
       deferredRegister.register("steel_axe",
-          () -> new AxeItem(RailcraftItemTier.STEEL, 8.0F, -3F,
+          () -> new AxeItem(RailcraftItemTier.STEEL, 5.5F, -3.0F,
               new Item.Properties()));
 
   public static final RegistryObject<HoeItem> STEEL_HOE =


### PR DESCRIPTION
**The Issue**
#292 - steel axe is better than a Netherite axe, dealing 11.5 damage at 1 attack speed (netherite axe is 10 damage at 1)
 
**The Proposal**
This pull request just rebalances the steel axe to be identical combat stats-wise to a diamond axe, making it the same as a diamond axe but with less durability
 
**Possible Side Effects**
The 1.21 branch will need to be updated as well, but this is a pretty minor change
 
**Alternatives**
simply not changing the axe stats, but that would leave #292 unresolved
