### PR TITLE
add config option for turbine power generation multiplier

### DIFF
--- a/src/main/java/mods/railcraft/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/RailcraftConfig.java
@@ -78,6 +78,8 @@ public class RailcraftConfig {
     public final DoubleValue fuelMultiplier;
     public final DoubleValue fuelPerSteamMultiplier;
 
+    public final DoubleValue turbinePowerMultiplier;
+
     public final IntValue cartDispenserDelay;
 
     public final BooleanValue changeDungeonLoot;
@@ -216,6 +218,14 @@ public class RailcraftConfig {
         this.fuelPerSteamMultiplier = builder
             .comment("Adjust the amount of fuel used to create steam.")
             .defineInRange("fuelPerSteamMultiplier", 1.0F, 0.2F, 6.0F);
+      }
+      builder.pop();
+
+      builder.push("rf");
+      {
+        this.turbinePowerMultiplier = builder
+            .comment("Adjust the amount of RF produced in a Turbine")
+            .defineInRange("turbinePowerMultiplier", 1.0F, 0.1F, 100F);
       }
       builder.pop();
 

--- a/src/main/java/mods/railcraft/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/RailcraftConfig.java
@@ -79,6 +79,7 @@ public class RailcraftConfig {
     public final DoubleValue fuelPerSteamMultiplier;
 
     public final DoubleValue turbinePowerMultiplier;
+    public final DoubleValue turbineEnergyOutputRateMultiplier;
 
     public final IntValue cartDispenserDelay;
 
@@ -210,6 +211,9 @@ public class RailcraftConfig {
         this.turbinePowerMultiplier = builder
             .comment("Adjust the amount of power produced in a Turbine")
             .defineInRange("turbinePowerMultiplier", 1.0F, 0.1F, 100F);
+        this.turbineEnergyOutputRateMultiplier = builder
+            .comment("Adjust the amount of energy output rate in a Turbine")
+            .defineInRange("turbineEnergyPowerRateMultiplier", 1.0F, 0.1F, 100F);
       }
       builder.pop();
 

--- a/src/main/java/mods/railcraft/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/RailcraftConfig.java
@@ -207,6 +207,9 @@ public class RailcraftConfig {
         this.lossMultiplier = builder
             .comment("Adjust the losses for the Charge network")
             .defineInRange("lossMultiplier", 1.0D, 0.2D, 10.0D);
+        this.turbinePowerMultiplier = builder
+            .comment("Adjust the amount of power produced in a Turbine")
+            .defineInRange("turbinePowerMultiplier", 1.0F, 0.1F, 100F);
       }
       builder.pop();
 
@@ -218,14 +221,6 @@ public class RailcraftConfig {
         this.fuelPerSteamMultiplier = builder
             .comment("Adjust the amount of fuel used to create steam.")
             .defineInRange("fuelPerSteamMultiplier", 1.0F, 0.2F, 6.0F);
-      }
-      builder.pop();
-
-      builder.push("rf");
-      {
-        this.turbinePowerMultiplier = builder
-            .comment("Adjust the amount of RF produced in a Turbine")
-            .defineInRange("turbinePowerMultiplier", 1.0F, 0.1F, 100F);
       }
       builder.pop();
 

--- a/src/main/java/mods/railcraft/world/level/block/SteamTurbineBlock.java
+++ b/src/main/java/mods/railcraft/world/level/block/SteamTurbineBlock.java
@@ -81,8 +81,8 @@ public class SteamTurbineBlock extends MultiblockBlock implements ChargeBlock {
       ServerLevel level, BlockPos pos) {
     return Spec.make(Charge.distribution, ChargeBlock.ConnectType.BLOCK, 0,
       new ChargeStorage.Spec(ChargeStorage.State.DISABLED,
-        (int) (SteamTurbineModule.CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get()),
-        (int) (SteamTurbineModule.CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get()),
+          SteamTurbineModule.CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get().intValue(),
+          SteamTurbineModule.CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get().intValue(),
         1));
   }
 

--- a/src/main/java/mods/railcraft/world/level/block/SteamTurbineBlock.java
+++ b/src/main/java/mods/railcraft/world/level/block/SteamTurbineBlock.java
@@ -2,10 +2,9 @@ package mods.railcraft.world.level.block;
 
 import java.util.List;
 import java.util.Map;
-
-import mods.railcraft.RailcraftConfig;
 import org.jetbrains.annotations.Nullable;
 import com.mojang.serialization.MapCodec;
+import mods.railcraft.RailcraftConfig;
 import mods.railcraft.Translations;
 import mods.railcraft.api.charge.Charge;
 import mods.railcraft.api.charge.ChargeBlock;

--- a/src/main/java/mods/railcraft/world/level/block/SteamTurbineBlock.java
+++ b/src/main/java/mods/railcraft/world/level/block/SteamTurbineBlock.java
@@ -2,6 +2,8 @@ package mods.railcraft.world.level.block;
 
 import java.util.List;
 import java.util.Map;
+
+import mods.railcraft.RailcraftConfig;
 import org.jetbrains.annotations.Nullable;
 import com.mojang.serialization.MapCodec;
 import mods.railcraft.Translations;
@@ -37,10 +39,6 @@ public class SteamTurbineBlock extends MultiblockBlock implements ChargeBlock {
 
   public static final Property<Boolean> ROTATED = BooleanProperty.create("rotated");
 
-  private static final Map<Charge, Spec> CHARGE_SPECS =
-      Spec.make(Charge.distribution, ChargeBlock.ConnectType.BLOCK, 0,
-          new ChargeStorage.Spec(ChargeStorage.State.DISABLED,
-              SteamTurbineModule.CHARGE_OUTPUT, SteamTurbineModule.CHARGE_OUTPUT, 1));
 
   private static final MapCodec<SteamTurbineBlock> CODEC = simpleCodec(SteamTurbineBlock::new);
 
@@ -82,7 +80,11 @@ public class SteamTurbineBlock extends MultiblockBlock implements ChargeBlock {
   @Override
   public Map<Charge, Spec> getChargeSpecs(BlockState state,
       ServerLevel level, BlockPos pos) {
-    return CHARGE_SPECS;
+    return Spec.make(Charge.distribution, ChargeBlock.ConnectType.BLOCK, 0,
+      new ChargeStorage.Spec(ChargeStorage.State.DISABLED,
+        (int) (SteamTurbineModule.CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get()),
+        (int) (SteamTurbineModule.CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get()),
+        1));
   }
 
   @Override

--- a/src/main/java/mods/railcraft/world/level/block/entity/SteamTurbineBlockEntity.java
+++ b/src/main/java/mods/railcraft/world/level/block/entity/SteamTurbineBlockEntity.java
@@ -94,7 +94,8 @@ public class SteamTurbineBlockEntity extends MultiblockBlockEntity<SteamTurbineB
               || !tank.getMembership().equals(blockEntity.getMembership());
 
           EnergyUtil.pushToSides(level, blockPos, master.getEnergyStorage(),
-                  (int) (ENERGY_OUTPUT_RATE * RailcraftConfig.SERVER.turbinePowerMultiplier.get()), filter, Direction.values());
+              ENERGY_OUTPUT_RATE * RailcraftConfig.SERVER.turbineEnergyOutputRateMultiplier.get().intValue(), filter,
+              Direction.values());
 
           var neighbors = FluidTools.findNeighbors(level, blockPos, filter,
               Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST);

--- a/src/main/java/mods/railcraft/world/level/block/entity/SteamTurbineBlockEntity.java
+++ b/src/main/java/mods/railcraft/world/level/block/entity/SteamTurbineBlockEntity.java
@@ -2,10 +2,9 @@ package mods.railcraft.world.level.block.entity;
 
 import java.util.List;
 import java.util.function.Predicate;
-
-import mods.railcraft.RailcraftConfig;
 import org.jetbrains.annotations.Nullable;
 import it.unimi.dsi.fastutil.chars.CharList;
+import mods.railcraft.RailcraftConfig;
 import mods.railcraft.Translations;
 import mods.railcraft.api.charge.Charge;
 import mods.railcraft.api.charge.ChargeStorage;

--- a/src/main/java/mods/railcraft/world/level/block/entity/SteamTurbineBlockEntity.java
+++ b/src/main/java/mods/railcraft/world/level/block/entity/SteamTurbineBlockEntity.java
@@ -2,6 +2,8 @@ package mods.railcraft.world.level.block.entity;
 
 import java.util.List;
 import java.util.function.Predicate;
+
+import mods.railcraft.RailcraftConfig;
 import org.jetbrains.annotations.Nullable;
 import it.unimi.dsi.fastutil.chars.CharList;
 import mods.railcraft.Translations;
@@ -93,7 +95,7 @@ public class SteamTurbineBlockEntity extends MultiblockBlockEntity<SteamTurbineB
               || !tank.getMembership().equals(blockEntity.getMembership());
 
           EnergyUtil.pushToSides(level, blockPos, master.getEnergyStorage(),
-              ENERGY_OUTPUT_RATE, filter, Direction.values());
+                  (int) (ENERGY_OUTPUT_RATE * RailcraftConfig.SERVER.turbinePowerMultiplier.get()), filter, Direction.values());
 
           var neighbors = FluidTools.findNeighbors(level, blockPos, filter,
               Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST);

--- a/src/main/java/mods/railcraft/world/module/SteamTurbineModule.java
+++ b/src/main/java/mods/railcraft/world/module/SteamTurbineModule.java
@@ -1,6 +1,8 @@
 package mods.railcraft.world.module;
 
 import java.util.concurrent.atomic.AtomicReference;
+
+import mods.railcraft.RailcraftConfig;
 import mods.railcraft.api.charge.Charge;
 import mods.railcraft.api.core.CompoundTagKeys;
 import mods.railcraft.tags.RailcraftTags;
@@ -59,13 +61,13 @@ public class SteamTurbineModule extends ChargeModule<SteamTurbineBlockEntity> {
   public void serverTick() {
     super.serverTick();
     var addedEnergy = false;
-    if (this.energy < CHARGE_OUTPUT) {
+    if (this.energy < (int) (CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get())) {
       var steam = this.steamTank.internalDrain(STEAM_USAGE, IFluidHandler.FluidAction.SIMULATE);
       if (steam.getAmount() >= STEAM_USAGE) {
         var rotorStack = this.rotorContainer.getItem(0);
         if (rotorStack.is(RailcraftItems.TURBINE_ROTOR.get())) {
           addedEnergy = true;
-          this.energy += CHARGE_OUTPUT;
+          this.energy += (int) (CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get());
           this.steamTank.internalDrain(STEAM_USAGE, IFluidHandler.FluidAction.EXECUTE);
           this.waterTank.internalFill(new FluidStack(Fluids.WATER, 2), IFluidHandler.FluidAction.EXECUTE);
           this.rotorContainer.setItem(0, useRotor((ServerLevel) this.provider.level(), rotorStack));

--- a/src/main/java/mods/railcraft/world/module/SteamTurbineModule.java
+++ b/src/main/java/mods/railcraft/world/module/SteamTurbineModule.java
@@ -60,13 +60,13 @@ public class SteamTurbineModule extends ChargeModule<SteamTurbineBlockEntity> {
   public void serverTick() {
     super.serverTick();
     var addedEnergy = false;
-    if (this.energy < (int) (CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get())) {
+    if (this.energy < (CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get().intValue())) {
       var steam = this.steamTank.internalDrain(STEAM_USAGE, IFluidHandler.FluidAction.SIMULATE);
       if (steam.getAmount() >= STEAM_USAGE) {
         var rotorStack = this.rotorContainer.getItem(0);
         if (rotorStack.is(RailcraftItems.TURBINE_ROTOR.get())) {
           addedEnergy = true;
-          this.energy += (int) (CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get());
+          this.energy += CHARGE_OUTPUT * RailcraftConfig.SERVER.turbinePowerMultiplier.get().intValue();
           this.steamTank.internalDrain(STEAM_USAGE, IFluidHandler.FluidAction.EXECUTE);
           this.waterTank.internalFill(new FluidStack(Fluids.WATER, 2), IFluidHandler.FluidAction.EXECUTE);
           this.rotorContainer.setItem(0, useRotor((ServerLevel) this.provider.level(), rotorStack));

--- a/src/main/java/mods/railcraft/world/module/SteamTurbineModule.java
+++ b/src/main/java/mods/railcraft/world/module/SteamTurbineModule.java
@@ -1,7 +1,6 @@
 package mods.railcraft.world.module;
 
 import java.util.concurrent.atomic.AtomicReference;
-
 import mods.railcraft.RailcraftConfig;
 import mods.railcraft.api.charge.Charge;
 import mods.railcraft.api.core.CompoundTagKeys;


### PR DESCRIPTION
**The Issue**
#201
 
**The Proposal**
This adds a config option in railcraft-server.toml that allows users to modify the amount of RF a steam turbine generates
 
**Possible Side Effects**
I had to change the `SteamTurbineBlock::getChargeSpecs` method to construct a new object to allow for the config option to affect the RF the turbine outputs as well as generates; additionally, this adds a call to query the config each tick in the `SteamTurbineBlockEntity` class. The config is already being queried each tick in other spots, like in the steam boiler classes, so I decided it was a negligible side effect. This is an avenue of optimization in the future, if necessary.
 
**Alternatives**
Just boosting the turbine power generation across the board is both less configurable and could ruin the balance of other energy consumers in the mod.
