### PR TITLE
map all forge creosote fluids to fluid boiler recipe (fixes #309 for 1.20)

### DIFF
--- a/src/main/java/mods/railcraft/integrations/jei/category/FluidBoilerRecipeCategory.java
+++ b/src/main/java/mods/railcraft/integrations/jei/category/FluidBoilerRecipeCategory.java
@@ -16,23 +16,27 @@ import mods.railcraft.api.core.RailcraftConstants;
 import mods.railcraft.integrations.jei.RailcraftJeiPlugin;
 import mods.railcraft.integrations.jei.RecipeTypes;
 import mods.railcraft.integrations.jei.recipe.FluidBoilerJEIRecipe;
+import mods.railcraft.tags.RailcraftTags;
 import mods.railcraft.world.item.RailcraftItems;
 import mods.railcraft.world.level.material.RailcraftFluids;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.registries.ForgeRegistries;
 
 public class FluidBoilerRecipeCategory implements IRecipeCategory<FluidBoilerJEIRecipe> {
 
   private static final int WIDTH = 117;
   private static final int HEIGHT = 54;
 
-  private static final ResourceLocation BACKGROUND =
-      RailcraftConstants.rl("textures/gui/container/fluid_fueled_steam_boiler.png");
+  private static final ResourceLocation BACKGROUND = RailcraftConstants
+      .rl("textures/gui/container/fluid_fueled_steam_boiler.png");
 
   private final IDrawable background, icon, flame, bar;
 
@@ -93,11 +97,16 @@ public class FluidBoilerRecipeCategory implements IRecipeCategory<FluidBoilerJEI
   }
 
   public static List<FluidBoilerJEIRecipe> getBoilerRecipes() {
-    // Not the actual capacity, but is 10000 for a better visibility
-    return List.of(
-        new FluidBoilerJEIRecipe(new FluidStack(RailcraftFluids.CREOSOTE.get(), 10_000),
+    TagKey<Fluid> CREOSOTE_TAG = RailcraftTags.Fluids.CREOSOTE;
+
+    return ForgeRegistries.FLUIDS.tags()
+        .getTag(CREOSOTE_TAG)
+        .stream()
+        .map(fluid -> new FluidBoilerJEIRecipe(
+            new FluidStack(fluid, 10_000),
             new FluidStack(Fluids.WATER, 10_000),
-            new FluidStack(RailcraftFluids.STEAM.get(), 10_000), 100)
-    );
+            new FluidStack(RailcraftFluids.STEAM.get(), 10_000),
+            100))
+        .toList();
   }
 }

--- a/src/main/java/mods/railcraft/integrations/jei/category/FluidBoilerRecipeCategory.java
+++ b/src/main/java/mods/railcraft/integrations/jei/category/FluidBoilerRecipeCategory.java
@@ -23,9 +23,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -35,8 +33,8 @@ public class FluidBoilerRecipeCategory implements IRecipeCategory<FluidBoilerJEI
   private static final int WIDTH = 117;
   private static final int HEIGHT = 54;
 
-  private static final ResourceLocation BACKGROUND = RailcraftConstants
-      .rl("textures/gui/container/fluid_fueled_steam_boiler.png");
+  private static final ResourceLocation BACKGROUND =
+      RailcraftConstants.rl("textures/gui/container/fluid_fueled_steam_boiler.png");
 
   private final IDrawable background, icon, flame, bar;
 
@@ -97,10 +95,8 @@ public class FluidBoilerRecipeCategory implements IRecipeCategory<FluidBoilerJEI
   }
 
   public static List<FluidBoilerJEIRecipe> getBoilerRecipes() {
-    TagKey<Fluid> CREOSOTE_TAG = RailcraftTags.Fluids.CREOSOTE;
-
     return ForgeRegistries.FLUIDS.tags()
-        .getTag(CREOSOTE_TAG)
+        .getTag(RailcraftTags.Fluids.CREOSOTE)
         .stream()
         .map(fluid -> new FluidBoilerJEIRecipe(
             new FluidStack(fluid, 10_000),


### PR DESCRIPTION
**The Issue**
https://github.com/railcraft-reborn/railcraft/issues/309
 
**The Proposal**
(scuffed) mapping of all creosote fluids matching the forge creosote tag in the FluidBoiler recipe
 
**Possible Side Effects**
Not sure
 
**Alternatives**
Ideally there's a forge API that takes in a FluidTag directly. I'm not very familiar with 1.20 forge apis, but there didn't seem to be any that supported a FluidTag directly from my light digging (like what was done here: https://github.com/railcraft-reborn/railcraft/commit/63123d3372be52df4d57ef16456a3f6a817ecc4b)
