### PR TITLE
Fixes #350: Add rail hitbox to Gated Track

### DIFF
--- a/src/main/java/mods/railcraft/world/level/block/track/outfitted/GatedTrackBlock.java
+++ b/src/main/java/mods/railcraft/world/level/block/track/outfitted/GatedTrackBlock.java
@@ -43,10 +43,10 @@ public class GatedTrackBlock extends ReversiblePoweredOutfittedTrackBlock {
 
   private static final double MOTION_MIN = 0.2D;
 
-  protected static final VoxelShape Z_SHAPE = Block.box(0.0D, 0.0D, 6.0D, 16.0D, 16.0D, 10.0D);
-  protected static final VoxelShape X_SHAPE = Block.box(6.0D, 0.0D, 0.0D, 10.0D, 16.0D, 16.0D);
-  protected static final VoxelShape Z_SHAPE_LOW = Block.box(0.0D, 0.0D, 6.0D, 16.0D, 13.0D, 10.0D);
-  protected static final VoxelShape X_SHAPE_LOW = Block.box(6.0D, 0.0D, 0.0D, 10.0D, 13.0D, 16.0D);
+  protected static final VoxelShape Z_SHAPE = Shapes.or(FLAT_AABB, Block.box(0.0D, 0.0D, 6.0D, 16.0D, 16.0D, 10.0D));
+  protected static final VoxelShape X_SHAPE = Shapes.or(FLAT_AABB, Block.box(6.0D, 0.0D, 0.0D, 10.0D, 16.0D, 16.0D));
+  protected static final VoxelShape X_SHAPE_LOW = Shapes.or(FLAT_AABB, Block.box(6.0D, 0.0D, 0.0D, 10.0D, 13.0D, 16.0D));
+  protected static final VoxelShape Z_SHAPE_LOW = Shapes.or(FLAT_AABB, Block.box(0.0D, 0.0D, 6.0D, 16.0D, 13.0D, 10.0D));
   protected static final VoxelShape Z_COLLISION_SHAPE =
       box(0.0D, 0.0D, 6.0D, 16.0D, 24.0D, 10.0D);
   protected static final VoxelShape X_COLLISION_SHAPE =


### PR DESCRIPTION
Fixes issue #350.

The buffer stop track already had the rail hitbox, so I copied over the `Shapes.or(FLAT_AABB, ...` from Buffer Stop to Gated.

https://github.com/railcraft-reborn/railcraft/blob/0126181e33e6a4065f55fd331ff906c801e1d8e4/src/main/java/mods/railcraft/world/level/block/track/outfitted/BufferStopTrackBlock.java#L22

This seems to work well from my testing, even when connected to a wall.