### PR TITLE
Fixes 346: add block/item tags to Buffer Stop tracks

### DIFF
--- a/src/generated/resources/.cache/4321ebcc8000f73dd5749a5c2d45335d60b185ec
+++ b/src/generated/resources/.cache/4321ebcc8000f73dd5749a5c2d45335d60b185ec
@@ -1,4 +1,4 @@
-// 1.21.1	2025-11-17T16:30:59.416033	Tags for minecraft:block mod id railcraft
+// 1.21.1	2026-01-07T02:20:43.270807346	Tags for minecraft:block mod id railcraft
 e36857f35c1bac4bde5a8450008b92cf82656216 data/c/tags/block/ore_rates/dense.json
 8ce5fa4b4f1c2619e124ef387b086d72f9c26f04 data/c/tags/block/ore_rates/singular.json
 135cfb50a5296d7842d36234ec1033fc2e454af4 data/c/tags/block/ores.json
@@ -21,29 +21,29 @@ e28c7fdf089f8fc76f9e5565d74f0293e412cfbc data/minecraft/tags/block/needs_iron_to
 e0dd6b3d5c00bb4625d93949af368b6cc90379c8 data/minecraft/tags/block/needs_stone_tool.json
 e1d606686d8d1ae939af83da8c931c49c2e9df5e data/minecraft/tags/block/rails.json
 9732f1964281f5d5e6f3d067e648bb4bfc5cbafb data/neoforge/tags/block/enderman_place_on_blacklist.json
-4276d58b0cb375037387fa9b749ae6b1e09d33c9 data/railcraft/tags/block/abandoned_track.json
+564ba471e816ad98403b775ce26d5dce54d344d6 data/railcraft/tags/block/abandoned_track.json
 9b21abe5b3e3997560ef95937505d9a8112afa92 data/railcraft/tags/block/abyssal.json
 5d37cf39d46349a6645d3f076a92aa2e94b9624e data/railcraft/tags/block/aspect_emitter.json
 192386fbb9d76dd115cb27c418ef2656209a93c4 data/railcraft/tags/block/aspect_receiver.json
 53a54148c37e39d19b70be13a370359fd0c3193b data/railcraft/tags/block/ballast.json
 ce3776760cd245b3be24a2863b4f4ab016e5b8ff data/railcraft/tags/block/detector.json
-592e64113a8afc0a5dafcdbf62ae4c012d67b168 data/railcraft/tags/block/electric_track.json
+1da7420fa39ba9c39afbcb881dfb77e05aabe518 data/railcraft/tags/block/electric_track.json
 6f70aa0939666b437b1f94030c02681a1a80eedf data/railcraft/tags/block/high_speed_electric_track.json
 6dc9632ad2d582c36b7dec9f486517003fb2b44e data/railcraft/tags/block/high_speed_track.json
 e428d6ae724c5108f98185295926eb14c6510c44 data/railcraft/tags/block/iron_tank_gauge.json
 ad43ddea7185867f695a872b9110aff36104b44d data/railcraft/tags/block/iron_tank_valve.json
 c84bc8091a2ddab656bbcac68ac18060ef1b9eb0 data/railcraft/tags/block/iron_tank_wall.json
-3b9872bd73d41ad2a348f2e5ab20cefddfba67b6 data/railcraft/tags/block/iron_track.json
+b165abc6c10b0a39bc78084fa43257946d40b211 data/railcraft/tags/block/iron_track.json
 77690ba158209beb37aa5436c376485258f75111 data/railcraft/tags/block/mineable/crowbar.json
 5c3ee0c8b144c2b48d062bca01cdc96427bb6c26 data/railcraft/tags/block/post.json
 1ecaf64f7b17425064c50cdd01fd826d38f37db5 data/railcraft/tags/block/quarried.json
 0295528cb5c194e5df814b65688466abcfd79833 data/railcraft/tags/block/quarried_replaceable_blocks.json
-8464d70cee360a2e5808a1d1d1c5b90d0230a38e data/railcraft/tags/block/reinforced_track.json
+603358b9f9e60cd909835228aa255fb7eb049170 data/railcraft/tags/block/reinforced_track.json
 cef2fe722cdf4386365bd961d925fa5aeb2e244e data/railcraft/tags/block/signal.json
 36dd475b78cc6cfda74baa55b8a7ba9919242524 data/railcraft/tags/block/steel_tank_gauge.json
 8bd3423ee85f552fd410fd0a24e26456019b1185 data/railcraft/tags/block/steel_tank_valve.json
 39074036a3b8c8bbad74fcad7dce1c559f82f107 data/railcraft/tags/block/steel_tank_wall.json
-4f443f634d9e8f3e783a576b578de32d8d9b802c data/railcraft/tags/block/strap_iron_track.json
+4aa94c50e6dfd8ffcd5876aa793e7a1262c70ef2 data/railcraft/tags/block/strap_iron_track.json
 3a7becb38c8d1c2314b0c3b33165fbb0a8abea1e data/railcraft/tags/block/strengthened_glass.json
 aef9e91cc72b4b67ad79db18ed826e6241996595 data/railcraft/tags/block/switch_track_actuator.json
 857a88edcb53ad2838d5471af89c751576924a82 data/railcraft/tags/block/track_undercutter_invalid_ballast.json

--- a/src/generated/resources/.cache/7cc9f5a39f84776d809436456ff87e0cabca2d5a
+++ b/src/generated/resources/.cache/7cc9f5a39f84776d809436456ff87e0cabca2d5a
@@ -1,4 +1,4 @@
-// 1.21.1	2025-02-01T19:25:01.226838	Tags for minecraft:item mod id railcraft
+// 1.21.1	2026-01-07T02:20:43.274294428	Tags for minecraft:item mod id railcraft
 e4b5c3cfded4b9b76efeda37728f26dc89261239 data/c/tags/item/armors/boots/steel.json
 5251495abc7cf69ab447d425014c585ffd3ee618 data/c/tags/item/armors/chestplates/steel.json
 e17d210ae3b04c5e5696fab17c38c94dcb437f75 data/c/tags/item/armors/helmets/steel.json
@@ -103,11 +103,11 @@ ec96409b13e00aacfd3a6d9f397e2ed76dda5165 data/minecraft/tags/item/foot_armor.jso
 c12118bda87efc5274515a86a0a7f3b189982de6 data/minecraft/tags/item/pickaxes.json
 15360ef6012773af817ef8496de52353494b4db3 data/minecraft/tags/item/shovels.json
 05168ea5fb65c2a597f1ca271644789e1dd9aa9c data/minecraft/tags/item/swords.json
-4276d58b0cb375037387fa9b749ae6b1e09d33c9 data/railcraft/tags/item/abandoned_track.json
+564ba471e816ad98403b775ce26d5dce54d344d6 data/railcraft/tags/item/abandoned_track.json
 9b21abe5b3e3997560ef95937505d9a8112afa92 data/railcraft/tags/item/abyssal.json
 3f5ccd47db2e1f5b813e0f1e606034d2ba9b53e6 data/railcraft/tags/item/crowbar.json
 ce3776760cd245b3be24a2863b4f4ab016e5b8ff data/railcraft/tags/item/detector.json
-592e64113a8afc0a5dafcdbf62ae4c012d67b168 data/railcraft/tags/item/electric_track.json
+1da7420fa39ba9c39afbcb881dfb77e05aabe518 data/railcraft/tags/item/electric_track.json
 789fd4d8051dd37cc25a0682024927162f331bc0 data/railcraft/tags/item/enchantments.json
 18f97a8f6200b56e94e454448233f41d49541550 data/railcraft/tags/item/gear_chest_loot.json
 6f70aa0939666b437b1f94030c02681a1a80eedf data/railcraft/tags/item/high_speed_electric_track.json
@@ -116,14 +116,14 @@ c414f3475af630884a5ab7ff5389c4eadb096fc8 data/railcraft/tags/item/ingot_chest_lo
 e428d6ae724c5108f98185295926eb14c6510c44 data/railcraft/tags/item/iron_tank_gauge.json
 ad43ddea7185867f695a872b9110aff36104b44d data/railcraft/tags/item/iron_tank_valve.json
 c84bc8091a2ddab656bbcac68ac18060ef1b9eb0 data/railcraft/tags/item/iron_tank_wall.json
-3b9872bd73d41ad2a348f2e5ab20cefddfba67b6 data/railcraft/tags/item/iron_track.json
+b165abc6c10b0a39bc78084fa43257946d40b211 data/railcraft/tags/item/iron_track.json
 29116defc8cf089cc6b3a1c93669c60463c981d7 data/railcraft/tags/item/plate_chest_loot.json
 5c3ee0c8b144c2b48d062bca01cdc96427bb6c26 data/railcraft/tags/item/post.json
 1ecaf64f7b17425064c50cdd01fd826d38f37db5 data/railcraft/tags/item/quarried.json
-8464d70cee360a2e5808a1d1d1c5b90d0230a38e data/railcraft/tags/item/reinforced_track.json
+603358b9f9e60cd909835228aa255fb7eb049170 data/railcraft/tags/item/reinforced_track.json
 36dd475b78cc6cfda74baa55b8a7ba9919242524 data/railcraft/tags/item/steel_tank_gauge.json
 8bd3423ee85f552fd410fd0a24e26456019b1185 data/railcraft/tags/item/steel_tank_valve.json
 39074036a3b8c8bbad74fcad7dce1c559f82f107 data/railcraft/tags/item/steel_tank_wall.json
-4f443f634d9e8f3e783a576b578de32d8d9b802c data/railcraft/tags/item/strap_iron_track.json
+4aa94c50e6dfd8ffcd5876aa793e7a1262c70ef2 data/railcraft/tags/item/strap_iron_track.json
 3a7becb38c8d1c2314b0c3b33165fbb0a8abea1e data/railcraft/tags/item/strengthened_glass.json
 701b4781c556d9e0eed70f3137cd5eebb22a9092 data/railcraft/tags/item/track_kit.json

--- a/src/generated/resources/data/railcraft/tags/block/abandoned_track.json
+++ b/src/generated/resources/data/railcraft/tags/block/abandoned_track.json
@@ -19,6 +19,7 @@
     "railcraft:abandoned_whistle_track",
     "railcraft:abandoned_locomotive_track",
     "railcraft:abandoned_throttle_track",
-    "railcraft:abandoned_routing_track"
+    "railcraft:abandoned_routing_track",
+    "railcraft:abandoned_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/block/electric_track.json
+++ b/src/generated/resources/data/railcraft/tags/block/electric_track.json
@@ -19,6 +19,7 @@
     "railcraft:electric_whistle_track",
     "railcraft:electric_locomotive_track",
     "railcraft:electric_throttle_track",
-    "railcraft:electric_routing_track"
+    "railcraft:electric_routing_track",
+    "railcraft:electric_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/block/iron_track.json
+++ b/src/generated/resources/data/railcraft/tags/block/iron_track.json
@@ -18,6 +18,7 @@
     "railcraft:iron_whistle_track",
     "railcraft:iron_locomotive_track",
     "railcraft:iron_throttle_track",
-    "railcraft:iron_routing_track"
+    "railcraft:iron_routing_track",
+    "railcraft:iron_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/block/reinforced_track.json
+++ b/src/generated/resources/data/railcraft/tags/block/reinforced_track.json
@@ -19,6 +19,7 @@
     "railcraft:reinforced_whistle_track",
     "railcraft:reinforced_locomotive_track",
     "railcraft:reinforced_throttle_track",
-    "railcraft:reinforced_routing_track"
+    "railcraft:reinforced_routing_track",
+    "railcraft:reinforced_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/block/strap_iron_track.json
+++ b/src/generated/resources/data/railcraft/tags/block/strap_iron_track.json
@@ -19,6 +19,7 @@
     "railcraft:strap_iron_whistle_track",
     "railcraft:strap_iron_locomotive_track",
     "railcraft:strap_iron_throttle_track",
-    "railcraft:strap_iron_routing_track"
+    "railcraft:strap_iron_routing_track",
+    "railcraft:strap_iron_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/item/abandoned_track.json
+++ b/src/generated/resources/data/railcraft/tags/item/abandoned_track.json
@@ -19,6 +19,7 @@
     "railcraft:abandoned_whistle_track",
     "railcraft:abandoned_locomotive_track",
     "railcraft:abandoned_throttle_track",
-    "railcraft:abandoned_routing_track"
+    "railcraft:abandoned_routing_track",
+    "railcraft:abandoned_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/item/electric_track.json
+++ b/src/generated/resources/data/railcraft/tags/item/electric_track.json
@@ -19,6 +19,7 @@
     "railcraft:electric_whistle_track",
     "railcraft:electric_locomotive_track",
     "railcraft:electric_throttle_track",
-    "railcraft:electric_routing_track"
+    "railcraft:electric_routing_track",
+    "railcraft:electric_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/item/iron_track.json
+++ b/src/generated/resources/data/railcraft/tags/item/iron_track.json
@@ -18,6 +18,7 @@
     "railcraft:iron_whistle_track",
     "railcraft:iron_locomotive_track",
     "railcraft:iron_throttle_track",
-    "railcraft:iron_routing_track"
+    "railcraft:iron_routing_track",
+    "railcraft:iron_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/item/reinforced_track.json
+++ b/src/generated/resources/data/railcraft/tags/item/reinforced_track.json
@@ -19,6 +19,7 @@
     "railcraft:reinforced_whistle_track",
     "railcraft:reinforced_locomotive_track",
     "railcraft:reinforced_throttle_track",
-    "railcraft:reinforced_routing_track"
+    "railcraft:reinforced_routing_track",
+    "railcraft:reinforced_buffer_stop_track"
   ]
 }

--- a/src/generated/resources/data/railcraft/tags/item/strap_iron_track.json
+++ b/src/generated/resources/data/railcraft/tags/item/strap_iron_track.json
@@ -19,6 +19,7 @@
     "railcraft:strap_iron_whistle_track",
     "railcraft:strap_iron_locomotive_track",
     "railcraft:strap_iron_throttle_track",
-    "railcraft:strap_iron_routing_track"
+    "railcraft:strap_iron_routing_track",
+    "railcraft:strap_iron_buffer_stop_track"
   ]
 }

--- a/src/main/java/mods/railcraft/data/RailcraftBlockTagsProvider.java
+++ b/src/main/java/mods/railcraft/data/RailcraftBlockTagsProvider.java
@@ -74,7 +74,8 @@ public class RailcraftBlockTagsProvider extends BlockTagsProvider {
             RailcraftBlocks.ABANDONED_WHISTLE_TRACK.get(),
             RailcraftBlocks.ABANDONED_LOCOMOTIVE_TRACK.get(),
             RailcraftBlocks.ABANDONED_THROTTLE_TRACK.get(),
-            RailcraftBlocks.ABANDONED_ROUTING_TRACK.get());
+            RailcraftBlocks.ABANDONED_ROUTING_TRACK.get(),
+            RailcraftBlocks.ABANDONED_BUFFER_STOP_TRACK.get());
     this.tag(RailcraftTags.Blocks.ELECTRIC_TRACK)
         .add(RailcraftBlocks.ELECTRIC_TRACK.get(),
             RailcraftBlocks.ELECTRIC_LOCKING_TRACK.get(),
@@ -95,7 +96,8 @@ public class RailcraftBlockTagsProvider extends BlockTagsProvider {
             RailcraftBlocks.ELECTRIC_WHISTLE_TRACK.get(),
             RailcraftBlocks.ELECTRIC_LOCOMOTIVE_TRACK.get(),
             RailcraftBlocks.ELECTRIC_THROTTLE_TRACK.get(),
-            RailcraftBlocks.ELECTRIC_ROUTING_TRACK.get());
+            RailcraftBlocks.ELECTRIC_ROUTING_TRACK.get(),
+            RailcraftBlocks.ELECTRIC_BUFFER_STOP_TRACK.get());
     this.tag(RailcraftTags.Blocks.HIGH_SPEED_TRACK)
         .add(RailcraftBlocks.HIGH_SPEED_TRACK.get(),
             RailcraftBlocks.HIGH_SPEED_TRANSITION_TRACK.get(),
@@ -141,7 +143,8 @@ public class RailcraftBlockTagsProvider extends BlockTagsProvider {
             RailcraftBlocks.IRON_WHISTLE_TRACK.get(),
             RailcraftBlocks.IRON_LOCOMOTIVE_TRACK.get(),
             RailcraftBlocks.IRON_THROTTLE_TRACK.get(),
-            RailcraftBlocks.IRON_ROUTING_TRACK.get());
+            RailcraftBlocks.IRON_ROUTING_TRACK.get(),
+            RailcraftBlocks.IRON_BUFFER_STOP_TRACK.get());
     this.tag(RailcraftTags.Blocks.REINFORCED_TRACK)
         .add(RailcraftBlocks.REINFORCED_TRACK.get(),
             RailcraftBlocks.REINFORCED_LOCKING_TRACK.get(),
@@ -162,7 +165,8 @@ public class RailcraftBlockTagsProvider extends BlockTagsProvider {
             RailcraftBlocks.REINFORCED_WHISTLE_TRACK.get(),
             RailcraftBlocks.REINFORCED_LOCOMOTIVE_TRACK.get(),
             RailcraftBlocks.REINFORCED_THROTTLE_TRACK.get(),
-            RailcraftBlocks.REINFORCED_ROUTING_TRACK.get());
+            RailcraftBlocks.REINFORCED_ROUTING_TRACK.get(),
+            RailcraftBlocks.REINFORCED_BUFFER_STOP_TRACK.get());
     this.tag(RailcraftTags.Blocks.STRAP_IRON_TRACK)
         .add(RailcraftBlocks.STRAP_IRON_TRACK.get(),
             RailcraftBlocks.STRAP_IRON_LOCKING_TRACK.get(),
@@ -183,7 +187,8 @@ public class RailcraftBlockTagsProvider extends BlockTagsProvider {
             RailcraftBlocks.STRAP_IRON_WHISTLE_TRACK.get(),
             RailcraftBlocks.STRAP_IRON_LOCOMOTIVE_TRACK.get(),
             RailcraftBlocks.STRAP_IRON_THROTTLE_TRACK.get(),
-            RailcraftBlocks.STRAP_IRON_ROUTING_TRACK.get());
+            RailcraftBlocks.STRAP_IRON_ROUTING_TRACK.get(),
+            RailcraftBlocks.STRAP_IRON_BUFFER_STOP_TRACK.get());
 
     this.tag(RailcraftTags.Blocks.SIGNAL)
         .add(RailcraftBlocks.BLOCK_SIGNAL.get(), RailcraftBlocks.DISTANT_SIGNAL.get(),


### PR DESCRIPTION
Fixes #346 

Simply added the buffer stop variants to the respective track type and ran datagen.