### PR TITLE
Fix #357: Make turbine rotors damageable

### DIFF
--- a/src/main/java/mods/railcraft/world/item/RailcraftItems.java
+++ b/src/main/java/mods/railcraft/world/item/RailcraftItems.java
@@ -136,7 +136,7 @@ public class RailcraftItems {
 
   public static final DeferredItem<TurbineRotorItem> TURBINE_ROTOR =
       deferredRegister.registerItem("turbine_rotor", properties ->
-          new TurbineRotorItem(properties.stacksTo(1)));
+          new TurbineRotorItem(properties.stacksTo(1).durability(30_000)));
 
   public static final DeferredItem<BlockItem> STEAM_TURBINE =
       blockItem(RailcraftBlocks.STEAM_TURBINE);

--- a/src/main/java/mods/railcraft/world/item/TurbineRotorItem.java
+++ b/src/main/java/mods/railcraft/world/item/TurbineRotorItem.java
@@ -10,16 +10,6 @@ public class TurbineRotorItem extends Item {
   }
 
   @Override
-  public int getMaxDamage(ItemStack stack) {
-    return 30_000;
-  }
-
-  @Override
-  public boolean isDamageable(ItemStack stack) {
-    return true;
-  }
-
-  @Override
   public boolean isBookEnchantable(ItemStack stack, ItemStack book) {
     return false;
   }


### PR DESCRIPTION
Fixes #357
 
The code currently tries to override `getMaxDamage` on item which doesn't seem to work these days. This pull request makes the rotor damageable by adding the max damage to the item's properties.